### PR TITLE
Fix isize conversion that throws error on build target wasm32-unknown-unknown

### DIFF
--- a/src/convert.rs
+++ b/src/convert.rs
@@ -10,7 +10,7 @@ use crate::runtime::*;
 use crate::{lang::{Varity, Parameter, Identifier}, stdlib::RantStdResult};
 use cast::*;
 use cast::Error as CastError;
-use std::{rc::Rc, ops::{DerefMut, Deref}, cell::RefCell};
+use std::{rc::Rc, ops::{DerefMut, Deref}, cell::RefCell, convert::TryInto};
 
 /// Enables conversion from a native type to a `RantValue`.
 pub trait IntoRant {
@@ -77,7 +77,7 @@ macro_rules! rant_int_conversions {
             Ok($val)
           };
           (isize, $val:expr) => {
-            Ok($val as isize)
+            $val.try_into().map_err(|_| CastError::Overflow)
           };
           ($to:ident, $val:expr) => {
             $to($val)

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -77,7 +77,14 @@ macro_rules! rant_int_conversions {
             Ok($val)
           };
           (isize, $val:expr) => {
-            $val.try_into().map_err(|_| CastError::Overflow)
+            {
+              let val = $val;
+              val.try_into().map_err(|_| if val < 0 {
+                CastError::Underflow
+              } else {
+                CastError::Overflow
+              })
+            }
           };
           ($to:ident, $val:expr) => {
             $to($val)

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -77,7 +77,7 @@ macro_rules! rant_int_conversions {
             Ok($val)
           };
           (isize, $val:expr) => {
-            Ok(isize($val))
+            Ok($val as isize)
           };
           ($to:ident, $val:expr) => {
             $to($val)


### PR DESCRIPTION
This allows for the build target wasm32-unknown-unknown to compile (if the feature "js" is activated for the getrandom crate, which can be done in the library using this one, so it's not required to do it in here).